### PR TITLE
Correção na documentação do Adapter

### DIFF
--- a/docs/gof/adapter.md
+++ b/docs/gof/adapter.md
@@ -269,7 +269,6 @@ public class ViaCepEndereco {
   } 
 
  class CepServiceAdapter {
-    -viaCepService : ViaCepService
     +obterEndereco(String cep) Endereco
   }
   class EnderecoAdapter{
@@ -304,7 +303,7 @@ public class ViaCepEndereco {
 
 ```java
 
-public class ViaCepAdapter extends ViaCepService implements ServicoCep {
+public class CepServiceAdapter extends ViaCepService implements ServicoCep {
     @Override
     public Endereco obterEndereco(String cep) { 
         return new EnderecoAdapter(lookup(cep));


### PR DESCRIPTION
No último exemplo de adapter utilizando o código "externo" do ViaCep, o sr. decidiu utilizar o Class Adapter para servir de adapter para a classe ViaCepService(adaptee) do ViaCep, porém a classe CepServiceAdapter(adapter) possui um atributo do tipo ViaCepService no diagrama, fiz correção removendo esse atributo já que CepServiceAdapter extends ViaCepService. Por fim, apenas renomeei a classe ViaCepAdapter no código para CepServiceAdapter para o código ficar coerente com o diagrama.